### PR TITLE
bioparser.hpp: support building with Gcc 10

### DIFF
--- a/include/bioparser/bioparser.hpp
+++ b/include/bioparser/bioparser.hpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <exception>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Greetings,

When attempting to build various tools using bioparser.hpp with Gcc 10, the build crashes with errors such as the ones described on [Debian bug #957747](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=957747) or [#957748](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=957748).  Here is a relevant extract for reference:
```
[...]
/usr/include/bioparser/bioparser.hpp: In lambda function:
/usr/include/bioparser/bioparser.hpp:839:24: error: ‘invalid_argument’ is not a member of ‘std’
  839 |             throw std::invalid_argument("[bioparser::SamParser] error: "
      |                        ^~~~~~~~~~~~~~~~
/usr/include/bioparser/bioparser.hpp:867:24: error: ‘invalid_argument’ is not a member of ‘std’
  867 |             throw std::invalid_argument("[bioparser::SamParser] error: "
      |                        ^~~~~~~~~~~~~~~~
/usr/include/bioparser/bioparser.hpp: In member function ‘bool bioparser::SamParser<T>::parse(std::vector<std::unique_ptr<T> >&, uint64_t, bool)’:
/usr/include/bioparser/bioparser.hpp:891:28: error: ‘invalid_argument’ is not a member of ‘std’
  891 |                 throw std::invalid_argument("[bioparser::SamParser] error: "
      |                            ^~~~~~~~~~~~~~~~
```
This is caused because a few functions, such as _std::invalid_argument_ in that particular case, are not implicitely loaded by some headers anymore and now require including _stdexcept_.  See [Gnu recommendations for porting C++ code to Gcc 10](https://gcc.gnu.org/gcc-10/porting_to.html) for more details.

This patch allows to move forward with building _bioparser_ based tools with Gcc 10.

I hope this helps,
Kind Regards.